### PR TITLE
acs_url特定のロジックを変更

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -60,11 +60,7 @@ module SamlIdp
     end
 
     def acs_url
-      pp 'acs'
-      pp service_provider
-      pp service_provider.acs_url
-      service_provider.acs_url ||
-        authn_request["AssertionConsumerServiceURL"].to_s
+      authn_request["AssertionConsumerServiceURL"].to_s || service_provider.acs_url
     end
 
     def logout_url
@@ -72,8 +68,6 @@ module SamlIdp
     end
 
     def response_url
-      pp 'response_url'
-      pp authn_request?
       if authn_request?
         acs_url
       elsif logout_request?
@@ -109,10 +103,6 @@ module SamlIdp
         log "Unable to find response url for #{issuer}: #{raw_xml}"
         return false
       end
-
-      pp service_provider
-      pp service_provider.acceptable_response_hosts
-      pp response_host
 
       if !service_provider.acceptable_response_hosts.include?(response_host)
         log "No acceptable AssertionConsumerServiceURL, either configure them via config.service_provider.response_hosts or match to your metadata_url host"

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -60,6 +60,10 @@ module SamlIdp
     end
 
     def acs_url
+      pp 'acs_url'
+      pp authn_request["AssertionConsumerServiceURL"]
+      pp authn_request["AssertionConsumerServiceURL"].to_s
+      pp service_provider.acs_url
       authn_request["AssertionConsumerServiceURL"].to_s || service_provider.acs_url
     end
 

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -105,6 +105,10 @@ module SamlIdp
         return false
       end
 
+      pp service_provider
+      pp service_provider.acceptable_response_hosts
+      pp response_host
+
       if !service_provider.acceptable_response_hosts.include?(response_host)
         log "No acceptable AssertionConsumerServiceURL, either configure them via config.service_provider.response_hosts or match to your metadata_url host"
         return false

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -60,11 +60,11 @@ module SamlIdp
     end
 
     def acs_url
-      pp 'acs_url'
-      pp authn_request["AssertionConsumerServiceURL"]
-      pp authn_request["AssertionConsumerServiceURL"].to_s
-      pp service_provider.acs_url
-      authn_request["AssertionConsumerServiceURL"].to_s || service_provider.acs_url
+      if authn_request["AssertionConsumerServiceURL"]
+        authn_request["AssertionConsumerServiceURL"].to_s
+      else
+        service_provider.acs_url
+      end
     end
 
     def logout_url

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -60,6 +60,9 @@ module SamlIdp
     end
 
     def acs_url
+      pp 'acs'
+      pp service_provider
+      pp service_provider.acs_url
       service_provider.acs_url ||
         authn_request["AssertionConsumerServiceURL"].to_s
     end
@@ -69,6 +72,8 @@ module SamlIdp
     end
 
     def response_url
+      pp 'response_url'
+      pp authn_request?
       if authn_request?
         acs_url
       elsif logout_request?


### PR DESCRIPTION
順序を入れ替えた理由

元々`service_provider.acs_url`を使ったことはなく、全てのアプリで`authn_request["AssertionConsumerServiceURL"]`を使用していた（リクエストに値が載って来ていた）

boxと連携する際にはじめて`service_provider.acs_url`を使用することとなった

そのため、以前のアプリへの影響を考えないで済むように順序を入れ替えた